### PR TITLE
Fix done date in NLD export

### DIFF
--- a/app/Exports/NldExport.php
+++ b/app/Exports/NldExport.php
@@ -71,8 +71,18 @@ class NldExport implements FromCollection, WithHeadings, WithMapping, ShouldAuto
             $nld->created,
             $nld->add_date,
             $nld->send_date,
-            $nld->done_date ?? optional($nld->doneStatuses->min('done_at'))->format('Y-m-d H:i:s'),
+            $this->resolveDoneDate($nld),
         ];
+    }
+
+    private function resolveDoneDate($nld)
+    {
+        if ($nld->done_date) {
+            return $nld->done_date;
+        }
+
+        $doneAt = $nld->doneStatuses->min('done_at');
+        return $doneAt ? \Carbon\Carbon::parse($doneAt)->format('d.m.Y H:i') : null;
     }
 
     public function headings(): array


### PR DESCRIPTION
## Summary
- include earliest group completion time in NLD Excel export so that Done Date is populated

## Testing
- `php --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68551379240c8324b9e0280de10d04ab