### PR TITLE
Fix group name export in NldExport

### DIFF
--- a/app/Exports/NldExport.php
+++ b/app/Exports/NldExport.php
@@ -62,7 +62,9 @@ class NldExport implements FromCollection, WithHeadings, WithMapping, ShouldAuto
             $nld->description,
             $nld->reporter_name,
             $nld->issue_type,
-            $nld->groups->pluck('name')->join(', ') ?? 'No group', // <-- исправлено
+            $nld->groups->isNotEmpty()
+                ? $nld->groups->pluck('name')->join(', ')
+                : 'No group',
             $nld->control_status,
             $nld->parent_issue_key,
             $nld->parent_issue_status,


### PR DESCRIPTION
## Summary
- fix group name export when no groups are assigned

## Testing
- `composer install` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685559b13e7883248a0a5f2394619293