### PR TITLE
Add catalog categories endpoint

### DIFF
--- a/app/Http/Controllers/CatalogController.php
+++ b/app/Http/Controllers/CatalogController.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Catalog;
+use Illuminate\Http\JsonResponse;
+
+class CatalogController extends Controller
+{
+    /**
+     * Return categories for the given catalog.
+     */
+    public function categories(Catalog $catalog): JsonResponse
+    {
+        return response()->json($catalog->categories);
+    }
+}

--- a/app/Models/Catalog.php
+++ b/app/Models/Catalog.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Catalog extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+    ];
+
+    /**
+     * Categories belonging to the catalog.
+     */
+    public function categories(): HasMany
+    {
+        return $this->hasMany(Category::class);
+    }
+}

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class Category extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'catalog_id',
+        'name',
+    ];
+
+    /**
+     * Catalog that this category belongs to.
+     */
+    public function catalog(): BelongsTo
+    {
+        return $this->belongsTo(Catalog::class);
+    }
+}

--- a/database/migrations/2025_06_01_000000_create_catalogs_table.php
+++ b/database/migrations/2025_06_01_000000_create_catalogs_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('catalogs', function (Blueprint $table) {
+            $table->id();
+            $table->string('name')->unique();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('catalogs');
+    }
+};

--- a/database/migrations/2025_06_01_000100_create_categories_table.php
+++ b/database/migrations/2025_06_01_000100_create_categories_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('categories', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('catalog_id')->constrained()->onDelete('cascade');
+            $table->string('name');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('categories');
+    }
+};

--- a/routes/web.php
+++ b/routes/web.php
@@ -4,6 +4,7 @@ use App\Http\Controllers\{AdminAnalyticsController,
     AdminController,
     AuthController,
     BackUpController,
+    CatalogController,
     CommentController,
     DashboardController,
     ExcelController,
@@ -75,6 +76,10 @@ Route::middleware('auth')->group(function () {
 
     Route::prefix('groups')->name('group.')->group(function () {
         Route::get('/list', [GroupController::class, 'myGroups'])->name('list');
+    });
+
+    Route::prefix('catalogs')->name('catalogs.')->group(function () {
+        Route::get('/{catalog}/categories', [CatalogController::class, 'categories'])->name('categories');
     });
 
     // Admin


### PR DESCRIPTION
## Summary
- add Catalog and Category models
- add migrations for catalogs and categories
- add CatalogController with categories action
- add routes to expose `/catalogs/{catalog}/categories`

## Testing
- `php -v` *(fails: command not found)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685971bc959c8324b3b9f45f589a61e7